### PR TITLE
Add dev mode toggle and component tree UI

### DIFF
--- a/extension/src/App.css
+++ b/extension/src/App.css
@@ -2,3 +2,46 @@
   padding: 1rem;
   font-family: sans-serif;
 }
+.app-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.component-tree ul {
+  list-style: none;
+  padding-left: 0;
+}
+
+.component-tree li {
+  cursor: pointer;
+  padding: 2px 4px;
+}
+
+.component-tree li.non-lit {
+  opacity: 0.6;
+}
+
+.component-tree li.updated {
+  border: 1px solid green;
+  animation: pulse 1.5s ease-out;
+}
+
+@keyframes pulse {
+  from {
+    background-color: rgba(0, 255, 0, 0.3);
+  }
+  to {
+    background-color: transparent;
+  }
+}
+
+.props-panel {
+  margin-top: 0.5rem;
+  border-top: 1px solid #ccc;
+  padding-top: 0.5rem;
+}
+
+.export-button {
+  margin-top: 1rem;
+}

--- a/extension/src/App.tsx
+++ b/extension/src/App.tsx
@@ -1,10 +1,15 @@
+import DevModeToggle from './components/DevModeToggle'
+import ComponentTree from './components/ComponentTree'
 import './App.css'
 
 export default function App() {
   return (
     <div className="app-container">
-      <h1>Lit Profiler</h1>
-      <p>DevTools panel coming soon.</p>
+      <header className="app-header">
+        <h1>Lit Profiler</h1>
+        <DevModeToggle />
+      </header>
+      <ComponentTree />
     </div>
   )
 }

--- a/extension/src/components/ComponentTree.tsx
+++ b/extension/src/components/ComponentTree.tsx
@@ -1,0 +1,110 @@
+import { useEffect, useState } from 'react'
+
+interface NodeInfo {
+  id: number
+  tag: string
+  isLit: boolean
+  element: Element
+  updated: boolean
+}
+
+function getInitialNodes(): NodeInfo[] {
+  const elements = Array.from(document.body.querySelectorAll('*'))
+  return elements.map((el, i) => ({
+    id: i,
+    tag: el.tagName.toLowerCase(),
+    isLit: el.tagName.includes('-'),
+    element: el,
+    updated: false,
+  }))
+}
+
+export default function ComponentTree() {
+  const [nodes, setNodes] = useState<NodeInfo[]>([])
+  const [showRaw, setShowRaw] = useState(false)
+  const [selected, setSelected] = useState<NodeInfo | null>(null)
+
+  useEffect(() => {
+    setNodes(getInitialNodes())
+
+    const observer = new MutationObserver((mutations) => {
+      const updated = new Set<Element>()
+      for (const m of mutations) {
+        if (m.target instanceof Element) {
+          updated.add(m.target)
+        }
+      }
+      if (updated.size > 0) {
+        setNodes((prev) =>
+          prev.map((n) => ({
+            ...n,
+            updated: updated.has(n.element) || n.updated,
+          })),
+        )
+        setTimeout(() => {
+          setNodes((prev) => prev.map((n) => ({ ...n, updated: false })))
+        }, 1500)
+      }
+    })
+
+    observer.observe(document.body, { attributes: true, childList: true, subtree: true })
+    return () => observer.disconnect()
+  }, [])
+
+  const renderProps = (el: Element) => {
+    const props: Record<string, unknown> = {}
+    for (const attr of Array.from(el.attributes)) {
+      props[attr.name] = attr.value
+    }
+    if (showRaw) {
+      return <pre>{JSON.stringify(props, null, 2)}</pre>
+    }
+    const entries = Object.entries(props).filter(([, v]) =>
+      ['string', 'number', 'boolean'].includes(typeof v),
+    )
+    return (
+      <ul>
+        {entries.map(([k, v]) => (
+          <li key={k}>
+            {k}: {String(v)}
+          </li>
+        ))}
+      </ul>
+    )
+  }
+
+  return (
+    <div className="component-tree">
+      <h2>Component Tree</h2>
+      <ul>
+        {nodes.map((n) => (
+          <li
+            key={n.id}
+            className={`${!n.isLit ? 'non-lit' : ''} ${n.updated ? 'updated' : ''}`}
+            onClick={() => setSelected(n)}
+          >
+            {n.tag} {!n.isLit && <span>(non-Lit)</span>}
+          </li>
+        ))}
+      </ul>
+      {selected && (
+        <div className="props-panel">
+          <h3>Props</h3>
+          <label>
+            <input type="checkbox" checked={showRaw} onChange={(e) => setShowRaw(e.target.checked)} />
+            Raw View
+          </label>
+          {renderProps(selected.element)}
+        </div>
+      )}
+      <button className="export-button" disabled title="Coming Soon: Export profiling session" onClick={() => exportDataToJson()}>
+        Export JSON
+      </button>
+    </div>
+  )
+}
+
+export function exportDataToJson() {
+  // Placeholder for future export functionality
+  console.log('exportDataToJson stub')
+}

--- a/extension/src/components/DevModeToggle.tsx
+++ b/extension/src/components/DevModeToggle.tsx
@@ -1,0 +1,39 @@
+import { useEffect, useState } from 'react'
+
+// Chrome typings are not included
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+declare const chrome: any
+
+type Mode = 'auto' | 'force-on' | 'force-off'
+
+export function DevModeToggle() {
+  const [mode, setMode] = useState<Mode>('auto')
+
+  useEffect(() => {
+    chrome?.storage?.local.get(['devMode']).then((result: { devMode?: Mode }) => {
+      if (result?.devMode) {
+        setMode(result.devMode)
+      }
+    })
+  }, [])
+
+  useEffect(() => {
+    chrome?.storage?.local.set({ devMode: mode }).catch(() => {})
+    document.body.dataset.mode = mode
+  }, [mode])
+
+  return (
+    <div className="dev-mode-toggle">
+      <label>
+        Mode:
+        <select value={mode} onChange={(e) => setMode(e.target.value as Mode)}>
+          <option value="auto">Auto</option>
+          <option value="force-on">Force On</option>
+          <option value="force-off">Force Off</option>
+        </select>
+      </label>
+    </div>
+  )
+}
+
+export default DevModeToggle


### PR DESCRIPTION
## Summary
- add DevModeToggle with Auto, Force On and Force Off modes
- display a basic component tree with props panel
- highlight recently updated elements
- mark non-Lit elements in the tree
- stub out Export JSON button

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6859e7b19b1c832c8ea6778a20695f9e